### PR TITLE
Fixes all-caps callouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 FROM ghcr.io/r-hub/r-minimal/r-minimal:4.4
 
 # Check https://carpentries.r-universe.dev/builds for latest versions of sandpaper, tinkr, pegboard and varnish
+ARG sandpaper_version=0.12.4
+ARG varnish_version=0.2.17
 RUN <<SANDPAPER
     installr -c
     installr -a "curl-dev linux-headers libxml2-dev fontconfig-dev harfbuzz-dev fribidi-dev freetype-dev tiff-dev jpeg-dev libgit2-dev libxslt-dev"
-    installr url::https://carpentries.r-universe.dev/src/contrib/sandpaper_0.12.4.tar.gz
-    installr url::https://carpentries.r-universe.dev/src/contrib/varnish_0.2.17.tar.gz
+    installr url::https://carpentries.r-universe.dev/src/contrib/sandpaper_${sandpaper_version}.tar.gz
+    installr url::https://carpentries.r-universe.dev/src/contrib/varnish_${varnish_version}.tar.gz
 SANDPAPER
 
+ARG pandoc_version=2.19.2
 RUN <<PANDOC
-    wget https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-linux-amd64.tar.gz
-    tar xzvf pandoc-3.1.2-linux-amd64.tar.gz
-    cp pandoc-3.1.2/bin/pandoc /bin/pandoc
+    wget https://github.com/jgm/pandoc/releases/download/${pandoc_version}/pandoc-${pandoc_version}-linux-amd64.tar.gz
+    tar xzvf pandoc-${pandoc_version}-linux-amd64.tar.gz
+    cp pandoc-${pandoc_version}/bin/pandoc /bin/pandoc
     rm -r pandoc*
 PANDOC
 


### PR DESCRIPTION
- Updates sandpaper and varnish
- Removes tinkr and pegboard manual installation
- Downgrades pandoc to 2.19.2
- Moves version numbers to ARGs